### PR TITLE
fix: lidarr genre panel label and legend incorrect

### DIFF
--- a/lidarr.json
+++ b/lidarr.json
@@ -772,13 +772,13 @@
           "format": "time_series",
           "instant": true,
           "interval": "",
-          "legendFormat": "{{quality}}",
+          "legendFormat": "{{genre}}",
           "refId": "A"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "qualities",
+      "title": "genres",
       "type": "bargauge"
     },
     {


### PR DESCRIPTION
Looks like this was copied from the qualities panel above it and never changed. This corrects both the panel label and time series legend. 